### PR TITLE
Initial Gun Affixes

### DIFF
--- a/src/main/java/dev/davey/apotheosis_ascended/ApotheosisAscended.java
+++ b/src/main/java/dev/davey/apotheosis_ascended/ApotheosisAscended.java
@@ -1,5 +1,6 @@
 package dev.davey.apotheosis_ascended;
 
+import dev.davey.apotheosis_ascended.attributes.AAAttributes;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -20,7 +21,9 @@ public class ApotheosisAscended
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::commonSetup);
         ApotheosisAscended.LOGGER.info("Loading Apotheosis Ascended");
+
         AALootCategories.init();
+        AAAttributes.ATTRIBUTES.register(modEventBus);
 
         MinecraftForge.EVENT_BUS.register(this);
     }

--- a/src/main/java/dev/davey/apotheosis_ascended/MixinConfigPlugin.java
+++ b/src/main/java/dev/davey/apotheosis_ascended/MixinConfigPlugin.java
@@ -22,6 +22,9 @@ public class MixinConfigPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("dev.davey.apotheosis_ascended.mixin.GunModifierHelperMixin")) {
+            return isModLoaded("scguns");
+        }
         return true;
     }
 

--- a/src/main/java/dev/davey/apotheosis_ascended/attributes/AAAttributes.java
+++ b/src/main/java/dev/davey/apotheosis_ascended/attributes/AAAttributes.java
@@ -1,0 +1,35 @@
+package dev.davey.apotheosis_ascended.attributes;
+
+import dev.davey.apotheosis_ascended.ApotheosisAscended;
+import dev.shadowsoffire.attributeslib.impl.PercentBasedAttribute;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class AAAttributes {
+    public static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(ForgeRegistries.ATTRIBUTES, ApotheosisAscended.MODID);
+
+    public static final RegistryObject<Attribute> KICK_REDUCTION = ATTRIBUTES.register("kick_reduction",
+            () -> new PercentBasedAttribute("attribute.apotheosis_ascended.kick_reduction", 0.0, 0.0, 1.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> PROJECTILE_SPEED = ATTRIBUTES.register("projectile_speed",
+            () -> new RangedAttribute("attribute.apotheosis_ascended.projectile_speed", 0.0, -0.99, 10.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> FIRE_RATE = ATTRIBUTES.register("fire_rate",
+            () -> new RangedAttribute("attribute.apotheosis_ascended.fire_rate", 0.0, -0.99, 10.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> ADDITIONAL_AMMO = ATTRIBUTES.register("additional_ammo",
+            () -> new RangedAttribute("attribute.apotheosis_ascended.additional_ammo", 0.0, 0.0, 100.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> SPREAD_REDUCTION = ATTRIBUTES.register("spread_reduction",
+            () -> new PercentBasedAttribute("attribute.apotheosis_ascended.spread_reduction", 0.0, 0.0, 1.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> RELOAD_SPEED = ATTRIBUTES.register("reload_speed",
+            () -> new RangedAttribute("attribute.apotheosis_ascended.reload_speed", 0.0, -0.99, 10.0).setSyncable(true));
+
+    public static final RegistryObject<Attribute> BULLET_DAMAGE = ATTRIBUTES.register("bullet_damage",
+            () -> new RangedAttribute("attribute.apotheosis_ascended.bullet_damage", 0.0, -0.99, 10.0).setSyncable(true));
+
+}

--- a/src/main/java/dev/davey/apotheosis_ascended/attributes/AAEntityAttributes.java
+++ b/src/main/java/dev/davey/apotheosis_ascended/attributes/AAEntityAttributes.java
@@ -1,0 +1,21 @@
+package dev.davey.apotheosis_ascended.attributes;
+
+import dev.davey.apotheosis_ascended.ApotheosisAscended;
+import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraft.world.entity.EntityType;
+
+@Mod.EventBusSubscriber(modid = ApotheosisAscended.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class AAEntityAttributes {
+    @SubscribeEvent
+    public static void onEntityAttributeModification(EntityAttributeModificationEvent event) {
+        event.add(EntityType.PLAYER, AAAttributes.KICK_REDUCTION.get());
+        event.add(EntityType.PLAYER, AAAttributes.PROJECTILE_SPEED.get());
+        event.add(EntityType.PLAYER, AAAttributes.FIRE_RATE.get());
+        event.add(EntityType.PLAYER, AAAttributes.ADDITIONAL_AMMO.get());
+        event.add(EntityType.PLAYER, AAAttributes.SPREAD_REDUCTION.get());
+        event.add(EntityType.PLAYER, AAAttributes.RELOAD_SPEED.get());
+        event.add(EntityType.PLAYER, AAAttributes.BULLET_DAMAGE.get());
+    }
+}

--- a/src/main/java/dev/davey/apotheosis_ascended/mixin/GunModifierHelperMixin.java
+++ b/src/main/java/dev/davey/apotheosis_ascended/mixin/GunModifierHelperMixin.java
@@ -1,0 +1,69 @@
+package dev.davey.apotheosis_ascended.mixin;
+
+import dev.davey.apotheosis_ascended.attributes.AAAttributes;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraftforge.registries.RegistryObject;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import top.ribs.scguns.util.GunModifierHelper;
+
+@Mixin(value = GunModifierHelper.class, remap = false)
+public class GunModifierHelperMixin {
+
+    @Unique
+    private static double apotheosisAscended$getAttributeValue(ItemStack weapon, RegistryObject<Attribute> attributeRO) {
+        return weapon.getAttributeModifiers(EquipmentSlot.MAINHAND).get(attributeRO.get()).stream()
+                .mapToDouble(AttributeModifier::getAmount)
+                .sum();
+    }
+
+    @ModifyReturnValue(method = "getModifiedProjectileSpeed", at = @At("RETURN"))
+    private static double onGetModifiedProjectileSpeed(double originalSpeed, ItemStack weapon, double speed) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.PROJECTILE_SPEED);
+        return originalSpeed * (1 + modifier);
+    }
+
+    @ModifyReturnValue(method = "getKickReduction", at = @At("RETURN"))
+    private static float onGetKickReduction(float originalReduction, ItemStack weapon) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.KICK_REDUCTION);
+        return originalReduction + (float)(modifier * (1 - originalReduction));
+    }
+
+    @ModifyReturnValue(method = "getModifiedRate", at = @At("RETURN"))
+    private static int onGetModifiedRate(int originalRate, ItemStack weapon, int rate) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.FIRE_RATE);
+        return (int) (originalRate / (1 + modifier));
+    }
+
+    @ModifyReturnValue(method = "getModifiedAmmoCapacity", at = @At("RETURN"))
+    private static int onGetModifiedAmmoCapacity(int originalCapacity, ItemStack weapon, top.ribs.scguns.common.Gun modifiedGun) {
+        double additionalAmmo = apotheosisAscended$getAttributeValue(weapon, AAAttributes.ADDITIONAL_AMMO);
+        return originalCapacity + (int)additionalAmmo;
+    }
+
+    @ModifyReturnValue(method = "getModifiedSpread", at = @At("RETURN"))
+    private static float onGetModifiedSpread(float originalSpread, ItemStack weapon, float spread) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.SPREAD_REDUCTION);
+        return originalSpread * (float)(1 - modifier);
+    }
+
+
+    @ModifyReturnValue(method = "getModifiedReloadSpeed", at = @At("RETURN"))
+    private static double onGetModifiedReloadSpeed(double originalReloadSpeed, ItemStack weapon, double reloadSpeed) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.RELOAD_SPEED);
+        return originalReloadSpeed / (1 + modifier);
+    }
+
+
+    @ModifyReturnValue(method = "getModifiedProjectileDamage", at = @At("RETURN"))
+    private static float onGetModifiedProjectileDamage(float originalDamage, ItemStack weapon, float damage) {
+        double modifier = apotheosisAscended$getAttributeValue(weapon, AAAttributes.BULLET_DAMAGE);
+        return originalDamage * (float)(1 + modifier);
+    }
+
+}

--- a/src/main/resources/assets/apotheosis_ascended/lang/en_us.json
+++ b/src/main/resources/assets/apotheosis_ascended/lang/en_us.json
@@ -1,0 +1,30 @@
+{
+  "attribute.apotheosis_ascended.kick_reduction": "Kick Reduction",
+  "attribute.apotheosis_ascended.projectile_speed": "Projectile Speed",
+  "attribute.apotheosis_ascended.fire_rate": "Fire Rate",
+  "attribute.apotheosis_ascended.additional_ammo": "Additional Ammo",
+  "attribute.apotheosis_ascended.spread_reduction": "Spread Reduction",
+  "attribute.apotheosis_ascended.reload_speed": "Reload Speed Increase",
+  "attribute.apotheosis_ascended.bullet_damage": "Damage",
+
+  "affix.apotheosis_ascended:gun/attribute/kick_reduction": "Stable",
+  "affix.apotheosis_ascended:gun/attribute/kick_reduction.suffix": "of Steadiness",
+
+  "affix.apotheosis_ascended:gun/attribute/projectile_speed": "Accelerated",
+  "affix.apotheosis_ascended:gun/attribute/projectile_speed.suffix": "of Velocity",
+
+  "affix.apotheosis_ascended:gun/attribute/fire_rate": "Rapid",
+  "affix.apotheosis_ascended:gun/attribute/fire_rate.suffix": "of Quick Firing",
+
+  "affix.apotheosis_ascended:gun/attribute/capacity": "Expanded",
+  "affix.apotheosis_ascended:gun/attribute/capacity.suffix": "of Abundance",
+
+  "affix.apotheosis_ascended:gun/attribute/spread_reduction": "Precise",
+  "affix.apotheosis_ascended:gun/attribute/spread_reduction.suffix": "of Accuracy",
+
+  "affix.apotheosis_ascended:gun/attribute/reload_speed": "Swift",
+  "affix.apotheosis_ascended:gun/attribute/reload_speed.suffix": "of Quick Hands",
+
+  "affix.apotheosis_ascended:gun/attribute/bullet_damage": "Powerful",
+  "affix.apotheosis_ascended:gun/attribute/bullet_damage.suffix": "of Destruction"
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/bullet_damage.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/bullet_damage.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:bullet_damage",
+  "operation": "MULTIPLY_BASE",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/capacity.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/capacity.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:additional_ammo",
+  "operation": "ADDITION",
+  "values": {
+    "common": {
+      "min": 1.0,
+      "steps": 1,
+      "step": 1.0
+    },
+    "uncommon": {
+      "min": 2.0,
+      "steps": 1,
+      "step": 1.0
+    },
+    "rare": {
+      "min": 3.0,
+      "steps": 1,
+      "step": 1.0
+    },
+    "epic": {
+      "min": 4.0,
+      "steps": 1,
+      "step": 1.0
+    },
+    "mythic": {
+      "min": 5.0,
+      "steps": 1,
+      "step": 1.0
+    },
+    "ancient": {
+      "min": 6.0,
+      "steps": 1,
+      "step": 1.0
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/fire_rate.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/fire_rate.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:fire_rate",
+  "operation": "MULTIPLY_BASE",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/kick_reduction.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/kick_reduction.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:kick_reduction",
+  "operation": "ADDITION",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/projectile_speed.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/projectile_speed.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:projectile_speed",
+  "operation": "MULTIPLY_BASE",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/reload_speed.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/reload_speed.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:reload_speed",
+  "operation": "MULTIPLY_BASE",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/spread_reduction.json
+++ b/src/main/resources/data/apotheosis_ascended/affixes/gun/attribute/spread_reduction.json
@@ -1,0 +1,40 @@
+{
+  "type": "apotheosis:attribute",
+  "attribute": "apotheosis_ascended:spread_reduction",
+  "operation": "ADDITION",
+  "values": {
+    "common": {
+      "min": 0.05,
+      "steps": 2,
+      "step": 0.05
+    },
+    "uncommon": {
+      "min": 0.10,
+      "steps": 2,
+      "step": 0.05
+    },
+    "rare": {
+      "min": 0.15,
+      "steps": 2,
+      "step": 0.05
+    },
+    "epic": {
+      "min": 0.20,
+      "steps": 2,
+      "step": 0.05
+    },
+    "mythic": {
+      "min": 0.25,
+      "steps": 2,
+      "step": 0.05
+    },
+    "ancient": {
+      "min": 0.30,
+      "steps": 2,
+      "step": 0.05
+    }
+  },
+  "types": [
+    "gun"
+  ]
+}

--- a/src/main/resources/mixins.json
+++ b/src/main/resources/mixins.json
@@ -5,6 +5,7 @@
     "refmap": "${modid}.refmap.json",
     "plugin": "dev.davey.apotheosis_ascended.MixinConfigPlugin",
     "mixins": [
+        "GunModifierHelperMixin"
     ],
     "client": [
     ],


### PR DESCRIPTION
### New Attributes (Hasn't been thoroughly tested):
These probably only work when applied directly to a gun, I haven't attempted to use them on other gear e.g. armor. 

**Kick Reduction** (`apotheosis_ascended:kick_reduction`): 
_Reduces recoil by (attribute value x 100)%._

**Projectile Speed** (`apotheosis_ascended:projectile_speed`): 
_Increases projectile velocity by (attribute value x 100)%._

**Fire Rate** (`apotheosis_ascended:fire_rate`): 
_Increases fire rate by (attribute value x 100)%._

**Additional Ammo** (`apotheosis_ascended:additional_ammo`): 
_Adds flat number of extra ammo slots._

**Spread Reduction** (`apotheosis_ascended:spread_reduction`): 
_Reduces spread by (attribute value x 100)%._

**Reload Speed** (`apotheosis_ascended:reload_speed`): 
_Decreases reload time by (attribute value x 100)%._

**Damage** (`apotheosis_ascended:damage`): 
_Increases bullet damage by (attribute value x 100)%._


Some rough affixes have been included mostly for testing purposes. I highly recommend sorting through these for balance, as well as double checking their functionality for all weapons.