### PR TITLE
Nerf gem applicability 

### DIFF
--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_blood.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_blood.json
@@ -9,7 +9,7 @@
 		"the_nether",
 		"overworld"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_eldritch.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_eldritch.json
@@ -9,7 +9,7 @@
 		"overworld",
         "the_end"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_ender.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_ender.json
@@ -8,7 +8,7 @@
 	"dimensions": [
 		"the_end"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_evocation.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_evocation.json
@@ -8,7 +8,7 @@
 	"dimensions": [
         "overworld"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_fire.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_fire.json
@@ -8,7 +8,7 @@
 	"dimensions": [
 		"the_nether"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_holy.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_holy.json
@@ -8,7 +8,7 @@
 	"dimensions": [
 		"overworld"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_ice.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_ice.json
@@ -9,7 +9,7 @@
 		"overworld",
         "the_end"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_lightning.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_lightning.json
@@ -8,7 +8,7 @@
 	"dimensions": [
 		"overworld"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_nature.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/innate_nature.json
@@ -8,7 +8,7 @@
 	"dimensions": [
 		"overworld"
 	],
-	"unique": false,
+	"unique": true,
 	"min_rarity": "rare",
 	"bonuses": [{
 			"type": "apotheosis:multi_attribute",

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_blood.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_blood.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_eldritch.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_eldritch.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_ender.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_ender.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_evocation.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_evocation.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_fire.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_fire.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_general.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_general.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_holy.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_holy.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_ice.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_ice.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_lightning.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_lightning.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},

--- a/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_nature.json
+++ b/src/main/resources/data/apotheosis_ascended/gems/additional_attributes_iss/spell_nature.json
@@ -12,15 +12,8 @@
 	"bonuses": [{
 			"type": "apotheosis:attribute",
 			"gem_class": {
-				"key": "anything",
+				"key": "helmet",
 				"types": [
-					"sword",
-					"trident",
-					"heavy_weapon",
-					"curios:spellbook",
-					"chestplate",
-					"leggings",
-					"boots",
 					"helmet"
 				]
 			},


### PR DESCRIPTION
This PR: 
- Makes School Level gems, which were previously unique but could be applied in any slot, only socketable in helmets. 

- Makes Spell Level gems, which were previously not unique, unique.

Fixed version of #26, without the accidentally included commits from #24 