### PR TITLE
Set up publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.7.0
+- Made School Level gems, which were previously unique but could be applied in any slot, only socketable in helmets.
+- Made Spell Level gems, which were previously not unique, unique.
+
+## 1.6.0
+- Affix compatibility with Scorched Guns (yes, you can now put affixes on guns)
+- Removed ISS Eldritch gems from spawning normally, will be re-implemented later

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.parchmentmc.librarian.forgegradle' version '1.+'
     id 'org.spongepowered.mixin' version '0.7-SNAPSHOT'
     id "net.darkhax.curseforgegradle" version "1.0.7"
+    id "com.modrinth.minotaur" version "2.+"
 }
 
 base {
@@ -283,18 +284,45 @@ reobf {
 
 jar.finalizedBy('reobfJarJar')
 
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
-    apiToken = System.getenv("CF_TOKEN")
+modrinth {
+    token = System.getenv("MODRINTH_TOKEN")
+    projectId = "apotheosis-ascended"
+    versionNumber = "${version}"
+    versionType = "release"
+    versionName = "Apotheosis Ascended ${rootProject.version}+${mc_version}"
+    changelog = new File("$project.rootDir/CHANGELOG.md").getText('UTF-8')
+    uploadFile = jar
+    gameVersions = forge_game_versions.split(", ").toList()
+    loaders = forge_mod_loaders.split(", ").collect { return it.toLowerCase(Locale.ROOT) }
+    dependencies {
+        required.project("additional-attributes")
+        required.project("tipsylib")
+        // required.project("apotheosis")
+        // not uploaded to modrinth
+    }
+}
 
-    def mainFile = upload(1055023, jar)
-    mainFile.displayName = "Forge/Neoforge-${rootProject.version}+${mc_version}"
+
+task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+    group = 'publishing'
+    apiToken = System.getenv("CF_TOKEN")
+    def mainFile = upload(1144178, jar)
+    mainFile.displayName = "Apotheosis Ascended ${rootProject.version}+${mc_version}"
     mainFile.releaseType = "release"
     mainFile.changelog = new File("$project.rootDir/CHANGELOG.md").getText('UTF-8')
     mainFile.changelogType = "markdown"
     forge_mod_loaders.split(", ").each {
         mainFile.addModLoader(it)
     }
-    forge_game_versions.split(", ").each {
-        mainFile.addGameVersion(it)
-    }
+    mainFile.addGameVersion("1.20.1")
+
+    mainFile.addRequirement("apotheosis")
+    mainFile.addRequirement("additional-attributes")
+    mainFile.addRequirement("tipsylib")
+}
+
+task publishAll {
+    dependsOn('publishCurseForge')
+    dependsOn('modrinth')
+    group = 'publishing'
 }


### PR DESCRIPTION
- Implements publishing gradle tasks via Modrinth Minotaur and Darkhax CurseForgeGradle

### How to use:
1. Create two system environment variables: `CF_TOKEN` and `MODRINTH_TOKEN` (get these from your user page for both platforms)
2. Update the `CHANGELOG.md` (You can leave any previous versions in, there seems to be no practical limit to changelog size)
3. Update the mod version in `gradle.properties` 
4. Run the existing `build` task
5. Run the new `publishAll` task

If you need to re-run a specific platform's upload process, you can run `modrinth` or `publishCurseforge` 